### PR TITLE
spring.datasource.driverClassNameの指定が壊れてしまっていた問題を修正

### DIFF
--- a/backend/app/src/main/resources/application.yaml
+++ b/backend/app/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     ansi:
       enabled: always
   datasource:
-    driverClassName: org:postgresql:Driver
+    driverClassName: org.postgresql.Driver
 doma:
   jdbc-logger: SLF4J
   dialect: postgres


### PR DESCRIPTION
プロパティファイルをyamlに変える時に、`.`を':'に一括置換したせいで壊れていました。